### PR TITLE
Delete duplicative "Statistical Discrimination" section.

### DIFF
--- a/trust-meter-tech-spec.md
+++ b/trust-meter-tech-spec.md
@@ -51,18 +51,6 @@ The Trust Meter Technical Specification is a framework that provides guidance fo
   - provides foundational guidance to support adoption but does not prescribe
     conformance requirements
 
-## Statistical Discrimination
-
-Mechanisms of statistical discrimination include:
-
-- The technical specification applies to machine‑learning‑based classification
-  systems used in decision‑making.
-- Generative and LLM‑based AI systems are out of scope unless they form a
-  component of a classification pipeline that produces consequential decisions.
-- The guidance is non‑normative and intended to support implementers, operators,
-  and reviewers.
-
-
 ## Definitions
 
 ### Example Trained – “ET”


### PR DESCRIPTION
I propose to delete this section, as it simply duplicates content from the Scope section. If there is actual content desired here, we should add it, although the ways in which machine learning tools can introduces bias and hence discrimination are described later in the document.
