### PR TITLE
Remove the reference in the Cover Note to an editorial comment later in the draft which no longer exists.

### DIFF
--- a/trust-meter-tech-spec.md
+++ b/trust-meter-tech-spec.md
@@ -14,8 +14,7 @@ types of additional commentary are sought:
     they are relevant.
 * Strategies not discussed in this draft for reducing the risk of discrimination
     associated with the use of AI systems directly or indirectly in
-    decision-making. A specific need for additional mitigations is highlighted
-    in the draft with a comment preceded by >>.
+    decision-making.
 * Examples or analyses indicating which of the strategies outlined in this draft
   have proven useful in mitigating risk in practice.
 


### PR DESCRIPTION
Remove an obsolete reference in the Cover Note.
