### PR TITLE
fix: remove pdf generation from ci

### DIFF
--- a/.github/workflows/convert-markdown.yml
+++ b/.github/workflows/convert-markdown.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        formats: [html, epub, docx, pdf]
+        # Removed PDF generation as Pandoc via Latex was running into issues converting the document.
+        formats: [html, epub, docx]
         fileNames: [trust-meter-tech-spec, spécification-technique-indicateur-de-confiance]
 
     steps:


### PR DESCRIPTION
* [x] This isn't a duplicate of an existing pull request

## Description

Due to issues with Latex conversion of the French translation of the tech spec, removing PDF generation from CI.